### PR TITLE
fix: normalize redirect location URI

### DIFF
--- a/src/test/resources/apis/v2/redirect.json
+++ b/src/test/resources/apis/v2/redirect.json
@@ -34,7 +34,7 @@
                         "rules": [
                             {
                                 "path": "/headers",
-                                "location": "https://httpbin.org/headers",
+                                "location": "https://httpbin.org//headers",
                                 "status": 302
                             },
                             {


### PR DESCRIPTION
see https://gravitee.atlassian.net/browse/GKO-1176
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.0.1-gko-1176-normalize-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-http-redirect/1.0.1-gko-1176-normalize-SNAPSHOT/gravitee-policy-http-redirect-1.0.1-gko-1176-normalize-SNAPSHOT.zip)
  <!-- Version placeholder end -->
