### PR TITLE
fix: regenerate docs using docgen

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -72,4 +72,6 @@ Please sign our https://download.gravitee.io/cla.pdf[Contributor License Agreeme
 
 == Further Information
 
-You can find more detailed information about contributing in the https://guides.github.com/activities/contributing-to-open-source/[Github guides].
+You can find more detailed information about contributing in the https://guides.github.com/activities/contributing-to-open-source/[Github guides]
+
+.


### PR DESCRIPTION
**Issue**

Compensate last commit that was "docs" hence didn't trigger a release

**Description**



**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.0.2-fix-force-release-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-http-redirect/1.0.2-fix-force-release-SNAPSHOT/gravitee-policy-http-redirect-1.0.2-fix-force-release-SNAPSHOT.zip)
  <!-- Version placeholder end -->
